### PR TITLE
Package.json cannot be parsed by npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.0.3",
   "description": "simple redis backed jobs runner",
   "author": "weepy",
-  "repository": "http://github.com/weepy/node-jobs",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/weepy/node-jobs"
+  },
   "dependencies": {
-    "redis": ">= 0.3.4",
+    "redis": ">= 0.3.4"
   },  
   "directories": { "lib": "./lib" },
   "engines" : { "node": ">= 0.2.0" }


### PR DESCRIPTION
When trying to install node-jobs, it will fail:

```
$ npm install jobs
[...]
npm ERR! Failed to parse json
npm ERR! Unexpected token }
[...]
npm not ok
$
```

This change fixes additional comma and updates repository url to the standards npm describes (http://npmjs.org/doc/json.html). Because I can't test a package.json, I am not sure whether these changes will fix the failure...
